### PR TITLE
ci: use P6_A_GH_TOKEN for upgrade-main

### DIFF
--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -12,4 +12,4 @@ jobs:
       - name: Upgrade Deps
         uses: p6m7g8-actions/cdk-construct-upgrade@main
         with:
-          gh_token: ${{ secrets.P6_PGOLLUCCI_GH_TOKEN}}
+          gh_token: ${{ secrets.P6_A_GH_TOKEN}}


### PR DESCRIPTION
Switch upgrade-main workflow token to `P6_A_GH_TOKEN` for consistent org/user automation behavior.